### PR TITLE
Fixes for podman

### DIFF
--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -14,7 +14,9 @@
 		"--security-opt",
 		"apparmor=unconfined",
 		"--userns=host",
-		"--hostname=ansible-dev-container"
+		"--hostname=ansible-dev-container",
+		"--volume",
+		"ansible-dev-tools-container-storage:/var/lib/containers"
 	],
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -1,23 +1,21 @@
 {
 	"name": "ansible-dev-container-podman",
 	"image": "ghcr.io/ansible/community-ansible-dev-tools:latest",
-	"containerUser": "podman",
+	"containerUser": "root",
 	"runArgs": [
-		"--security-opt",
-		"seccomp=unconfined",
-		"--security-opt",
-		"label=disable",
 		"--cap-add=SYS_ADMIN",
 		"--cap-add=SYS_RESOURCE",
 		"--device",
 		"/dev/fuse",
 		"--security-opt",
+		"seccomp=unconfined",
+		"--security-opt",
+		"label=disable",
+		"--security-opt",
 		"apparmor=unconfined",
-		"--userns=keep-id:uid=1000,gid=1000",
-		"--user=root",
+		"--userns=host",
 		"--hostname=ansible-dev-container"
 	],
-	"updateRemoteUserUID": true,
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ podman run 	-it --rm \
  --user=root \
  --userns=host \
  -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
+ -v ansible-dev-tools-container-storage:/var/lib/containers \
  -v $HOME/.gitconfig:/root/.gitconfig \
  -v $PWD:/workdir \
- -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK:Z \
+ -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK \
  ghcr.io/ansible/community-ansible-dev-tools:latest
 ```
 
@@ -118,6 +119,7 @@ Note:
 - This command will mount the current directory to `/workdir` in the container
 - The SSH agent socket is also mounted to the container to allow for SSH key forwarding. 
 - The user's `.gitconfig` is mounted to the container to allow for git operations.
+- The `ansible-dev-tools-container-storage` volume is mounted to the container to store the nested container images on the host.
 
 ### Signing git commits (SSH)
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ Alternatively, the public key can added in-line in the `gitconfig`
   signingkey = key:: ssh-rsa AAAAB3N
 ```
 
-
-
-user.signingkey
-
 ### Layering ADT and container-in-container support on a custom image
 
 In order to add the Ansible Devtools package and the container-in-container support with podman using a custom EE or another container image, you can use to the [final


### PR DESCRIPTION
- Set the `userns` to host, this causes files touched from inside the container to be owned by the default user
- Correct the devcontainer user for podman
-  Remove the user from the `runArgs` as the `containerUser` entry does the same thing
- Add some information to the README for podman and related to signing commits

Related docs:

https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey
https://github.com/microsoft/vscode-remote-release/issues/7796
https://docs.podman.io/en/latest/markdown/podman-run.1.html#userns-mode
