### PR TITLE
Add a breadcrumb for container detection

### DIFF
--- a/final/Containerfile
+++ b/final/Containerfile
@@ -88,6 +88,8 @@ RUN mkdir -p /var/lib/shared/overlay-images \
         touch /var/lib/shared/vfs-layers/layers.lock
 
 ENV _CONTAINERS_USERNS_CONFIGURED=""
+ENV ANSIBLE_DEV_TOOLS_CONTAINER=1
+
 
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.


### PR DESCRIPTION
Provide the ability to determine if we are running in an ansible-dev-tools container.  This can be used for troubleshooting or later for changing the behaviour of other tools, (e.g. ade to do a system install)